### PR TITLE
[Testing] Fix code coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install rustfmt
+      run: |
+        rustup component add rustfmt
+    
     - name: Generate code coverage
       run: |
         cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 /book/book
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["logos-cli", "logos-codegen", "logos-derive", "tests", "fuzz"]
+members = ["logos-cli", "logos-codegen", "logos-derive", "tests"]
+exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,16 +1,6 @@
 [package]
 name = "logos-fuzz"
-authors.workspace = true
-categories.workspace = true
-description.workspace = true
-edition.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-license.workspace = true
-readme.workspace = true
-repository.workspace = true
-rust-version.workspace = true
-version.workspace = true
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
While adding tests for the safe-only code PR, I noticed that the code coverage action hasn't been able to complete successfully for a while.

Originally this was caused by `rustfmt` not being available in the container. So this installs it before running coverage.

Additionally, there was a bad interaction between the new afl-based fuzzing functionality and the workspace (which also caused `cargo build --workspace` to fail with linking errors). This is because afl projects must be built with `cargo afl build` so it can link properly. To solve this, I just excluded the fuzz project from the workspace.
